### PR TITLE
fix: prevent window dragging in Electron apps by adding WebkitAppRegion no-drag

### DIFF
--- a/packages/scan/src/web/widget/index.tsx
+++ b/packages/scan/src/web/widget/index.tsx
@@ -702,6 +702,7 @@ export const Widget = () => {
             "will-change-transform",
             "[touch-action:none]"
           )}
+          style={{ WebkitAppRegion: "no-drag" }}
         >
           {/* this entire feature is vibe coded don't think too hard about the code its probably very non coherent */}
           {isCollapsed ? (


### PR DESCRIPTION
## Description

This PR adds the `WebkitAppRegion: 'no-drag'` CSS property to the React Scan widget to prevent accidental window dragging when users interact with the toolbar in Electron applications.

## Changes

- Added `style={{ WebkitAppRegion: 'no-drag' }}` to the main widget container div
- This prevents the Electron window from being dragged when users interact with React Scan controls

## Why this change?

In Electron applications, by default, users can drag the window by clicking and dragging on any part of the interface. This can interfere with the React Scan widget's functionality, as users might accidentally drag the window when trying to interact with the toolbar buttons or resize handles.

The `WebkitAppRegion: 'no-drag'` property specifically tells Electron that this area should not trigger window dragging behavior.

## Testing

- ✅ Verified the change only adds one line
- ✅ No formatting or linting issues introduced
- ✅ Widget functionality remains intact

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update